### PR TITLE
mtp: import fix for cpu utilization

### DIFF
--- a/mtp/ffs/MtpFfsHandle.cpp
+++ b/mtp/ffs/MtpFfsHandle.cpp
@@ -48,6 +48,9 @@ constexpr unsigned FFS_NUM_EVENTS = 5;
 constexpr unsigned MAX_FILE_CHUNK_SIZE = AIO_BUFS_MAX * AIO_BUF_LEN;
 
 constexpr uint32_t MAX_MTP_FILE_SIZE = 0xFFFFFFFF;
+// Note: POLL_TIMEOUT_MS = 0 means return immediately i.e. no sleep.
+// And this will cause high CPU usage.
+constexpr int32_t POLL_TIMEOUT_MS = 500;
 
 struct timespec ZERO_TIMEOUT = { 0, 0 };
 
@@ -305,7 +308,7 @@ int MtpFfsHandle::waitEvents(__attribute__((unused)) struct io_buffer *buf, int 
 	int error = 0;
 
 	while (num_events < min_events) {
-		if (poll(mPollFds, 2, 0) == -1) {
+		if (poll(mPollFds, 2, POLL_TIMEOUT_MS) == -1) {
 			MTPE("Mtp error during poll()\n");
 			return -1;
 		}


### PR DESCRIPTION
commit f2388b3c23754f33f9bba1f73c0b2ca57f00e546
Author: James Wei <jameswei@google.com>
Date:   Tue Dec 18 17:39:58 2018 +0800

    MTP: CPU usage high while under MTP mode.

    poll timeout not setting well in MTP ffs handler.
    This will cause MTP ffs handler not going into sleep mode.

    Bug: 121171744
    Test: MTP 500 Mbyte file copy throughput from / to Host (no drop)
    Change-Id: I9b8a7257670b8e536bf2ea81118d297211254984

Change-Id: Ic79f6b04334074c73b62325b53112719ba29255d

# WE DO NOT MERGE PULL REQUESTS SUBMITTED HERE

You will need to submit it through [OmniRom Gerrit](https://gerrit.omnirom.org/#/admin/projects/android_bootable_recovery/)

For changes to device trees, use [TWRP Gerrit](https://gerrit.twrp.me/)

This guide explani how to use [Gerrit code review](https://forum.xda-developers.com/general/xda-university/guide-using-gerrit-code-review-t3720802)